### PR TITLE
validate chosen time_slot on empty schedule days

### DIFF
--- a/app/services/google_calendar.rb
+++ b/app/services/google_calendar.rb
@@ -103,10 +103,13 @@ class GoogleCalendar
     day_end = Time.now.change(hour: day_end).advance(days: repetition + @skipped_days)
     searching = true
     while searching
-      busy_times = fetch_busy_times(day_start.today? ? Time.now.iso8601 : day_start.iso8601, day_end.iso8601)
+      busy_times = day_start.today? ? fetch_busy_times(Time.now.iso8601, day_end.iso8601) : fetch_busy_times(day_start.iso8601, day_end.iso8601)
       if busy_times.empty?
+        time_slot = handle_empty_schedule(day_start, task_duration)
+        next unless valid_time_slot?(time_slot[:start], time_slot[:end], day_start, day_end, task_duration)
+
         searching = false
-        return handle_empty_schedule(day_start, task_duration)
+        return time_slot
       end
 
       busy_times.each_with_index do |busy_time, index|


### PR DESCRIPTION
Fixed a bug where same-day scheduled events could appear past the `day_end` maximum.