### PR TITLE
Token expiration rescue

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,7 +4,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if @user.persisted?
       auth = request.env["omniauth.auth"]
       @user.access_token = auth.credentials.token
-      @user.expires_at = auth.credentials.expires_at
+      @user.expires_at = Time.at(auth.credentials.expires_at)
       @user.refresh_token = auth.credentials.refresh_token
       @user.save!
       sign_in(@user)


### PR DESCRIPTION
Properly log user out when their Google Calendar login token's have expired.